### PR TITLE
replace `switch.val` with `switch.or_panic` and `switch.or_default`

### DIFF
--- a/2023/01/part1.fz
+++ b/2023/01/part1.fz
@@ -8,8 +8,8 @@ dec1 is
     while l != ""  do
       digits := l.codepoints
                  .filter x->(codepoint.type.ascii_digit.contains x.val)
-      first := digits.first.val.parse_i32.val
-      last  := digits.last .val.parse_i32.val
+      first := digits.first.or_panic.parse_i32.or_panic
+      last  := digits.last .or_panic.parse_i32.or_panic
     else
       sum
 

--- a/2023/01/part2.fz
+++ b/2023/01/part2.fz
@@ -11,8 +11,8 @@ dec1 is
     while l != ""  do
       digits := l.codepoints
                 .filter x->(codepoint.type.ascii_digit.contains x.val)
-      first := digits.first.val.parse_i32.val
-      last  := digits.last .val.parse_i32.val
+      first := digits.first.or_panic.parse_i32.or_panic
+      last  := digits.last .or_panic.parse_i32.or_panic
     else
       sum
 
@@ -48,8 +48,8 @@ dec1 is
       d := text_to_digit l
       digits := d.codepoints
                 .filter x->(codepoint.type.ascii_digit.contains x.val)
-      first := digits.first.val.parse_i32.val
-      last  := digits.last .val.parse_i32.val
+      first := digits.first.or_panic.parse_i32.or_panic
+      last  := digits.last .or_panic.parse_i32.or_panic
     else
       sum
 

--- a/2023/02/part1.fz
+++ b/2023/02/part1.fz
@@ -9,7 +9,7 @@ dec2 is
 
   draw(s) is
     color(col) => s.split ","
-                   .map c->(c.ends_with col ? (c.split " ")[1].parse_i32.val : 0)
+                   .map c->(c.ends_with col ? (c.split " ")[1].parse_i32.or_panic: 0)
                    .fold i32.type.sum
     r := color "red"
     g := color "green"
@@ -17,7 +17,7 @@ dec2 is
 
   game(s) is
     s1 := s.split ":"
-    num   := (s1[0].split " ")[1].parse_i32.val
+    num   := (s1[0].split " ")[1].parse_i32.or_panic
     draws := (s1[1].split ";").map (x->draw x)
 
   LM : mutate is

--- a/2023/02/part1_dirty.fz
+++ b/2023/02/part1_dirty.fz
@@ -9,15 +9,15 @@ dec2 is
 
   draw(s String) is
     cubes := s.split ","
-    red   := (cubes.map c->(c.ends_with "red"   ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum
-    green := (cubes.map c->(c.ends_with "green" ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum
-    blue  := (cubes.map c->(c.ends_with "blue"  ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum
+    red   := (cubes.map c->(c.ends_with "red"   ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum
+    green := (cubes.map c->(c.ends_with "green" ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum
+    blue  := (cubes.map c->(c.ends_with "blue"  ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum
     public redef as_string String => "$red red, $green green, $blue blue"
 
   game(s String) is
     s1 := s.split(":")
     game := s1[0]
-    num := (game.split " ")[1].parse_i32.val
+    num := (game.split " ")[1].parse_i32.or_panic
     draws := (s1[1].split ";").map (x->draw x)   # NYI: partial `draw` did not work?
     public redef as_string String => "$game: {draws.as_string "; "}"
 

--- a/2023/02/part2.fz
+++ b/2023/02/part2.fz
@@ -17,13 +17,13 @@ dec2 is
 
   draw(s) =>
     color(col) => s.split ","
-                   .map c->(c.ends_with col ? (c.split " ")[1].parse_i32.val : 0)
+                   .map c->(c.ends_with col ? (c.split " ")[1].parse_i32.or_panic: 0)
                    .fold i32.type.sum
     bag (color "red") (color "green") (color "blue")
 
   game(s) is
     s1 := s.split ":"
-    num   := (s1[0].split " ")[1].parse_i32.val
+    num   := (s1[0].split " ")[1].parse_i32.or_panic
     draws := (s1[1].split ";").map (x->draw x)
     min => draws.fold bag_min
 

--- a/2023/02/part2_dirty.fz
+++ b/2023/02/part2_dirty.fz
@@ -24,15 +24,15 @@ dec2 is
 
   draw(s String) is
     cubes := s.split ","
-    b := (bag ((cubes.map c->(c.ends_with "red"   ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum)
-              ((cubes.map c->(c.ends_with "green" ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum)
-              ((cubes.map c->(c.ends_with "blue"  ? (c.split " ")[1].parse_i32.val : 0)).fold i32.type.sum))
+    b := (bag ((cubes.map c->(c.ends_with "red"   ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum)
+              ((cubes.map c->(c.ends_with "green" ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum)
+              ((cubes.map c->(c.ends_with "blue"  ? (c.split " ")[1].parse_i32.or_panic: 0)).fold i32.type.sum))
     public redef as_string String => $b
 
   game(s String) is
     s1 := s.split(":")
     game := s1[0]
-    num := (game.split " ")[1].parse_i32.val
+    num := (game.split " ")[1].parse_i32.or_panic
     draws := (s1[1].split ";").map (x->draw x)   # NYI: partial `draw` did not work?
     min => (draws.map (.b)).fold bag_min_monoid
     public redef as_string String => "$game: {draws.as_string "; "}"

--- a/2023/03/part1.fz
+++ b/2023/03/part1.fz
@@ -14,10 +14,10 @@ dec3_part1 is
       if 0 <= l < h && 0 <= c < w then a[_,l,c] else "."
 
     number(l, c i32) is
-      len := (0.. .filter (x -> !(at l c+x).is_ascii_digit)).first.val
+      len := (0.. .filter (x -> !(at l c+x).is_ascii_digit)).first.or_panic
       ok bool := (-1..1) ∃ y -> (-1..len) ∃ x -> (at l+y c+x) .is_symbol
       val i32 := ls[l].substring c c+len
-                      .parse_i32.val
+                      .parse_i32.or_panic
 
     numbers =>
       a.index_pairs.flat_map number ij->

--- a/2023/03/part1_dirty.fz
+++ b/2023/03/part1_dirty.fz
@@ -32,7 +32,7 @@ dec3_part1 is
                   !(-1..len+1).filter x->s1[l+y,c+x].is_symbol
                               .is_empty
                .is_empty
-    val => str.parse_i32.val
+    val => str.parse_i32.or_panic
 
   find_numbers(s1) =>
     for
@@ -58,7 +58,7 @@ dec3_part1 is
 
   s := read_scheme
   n := find_numbers s
-  r := n.filter x->x.ok
-        .map x->x.val
+  r := n.filter (.ok)
+        .map (.val)
         .fold i32.type.sum
   say r

--- a/2023/03/part2.fz
+++ b/2023/03/part2.fz
@@ -17,10 +17,10 @@ dec3_part2 is
       if 0 <= l < h && 0 <= c < w then a[_,l,c] else "."
 
     number(l, c i32) is
-      len := (0.. .filter (x -> !(at l c+x).is_ascii_digit)).first.val
+      len := (0.. .filter (x -> !(at l c+x).is_ascii_digit)).first.or_panic
       ok bool := (-1..1) ∃ y -> (-1..len) ∃ x -> (at l+y c+x) .is_symbol
       val i32 := ls[l].substring c c+len
-                      .parse_i32.val
+                      .parse_i32.or_panic
       adj (i,j i32) => (l-1 <= i <= l+1   &&
                         c-1 <= j <= c+len   )
 
@@ -40,7 +40,7 @@ dec3_part2 is
          i,j := ij
          if at i j = "*"
            k := numbers.filter (x -> x.adj i j)
-           if k.count = 2 then k.first.val.val * k.last.val.val else 0
+           if k.count = 2 then k.first.or_panic.val * k.last.or_panic.val else 0
          else
            0
        .fold i32.type.sum

--- a/2023/03/part2_dirty.fz
+++ b/2023/03/part2_dirty.fz
@@ -19,7 +19,7 @@ dec3_part2 is
       val := (0..len-1).map i->scheme.this[l,c+i].as_string
                        .fold String.type.concat
                        .parse_i32
-                       .val
+                       .or_panic
       adj (i,j i32) => (l-1 <= i <= l+1   &&
                         c-1 <= j <= c+len   )
 
@@ -39,8 +39,8 @@ dec3_part2 is
       else res
 
     parts =>
-      numbers.filter x->x.ok
-             .map x->x.val
+      numbers.filter (.ok)
+             .map (.val)
              .fold i32.type.sum
 
     gears =>
@@ -52,7 +52,7 @@ dec3_part2 is
             if scheme.this[i,j] = "*"
               k := numbers.filter (x->x.adj i j)
               if k.count = 2
-                res <- res.get + k.map x->x.val
+                res <- res.get + k.map (.val)
                                   .fold i32.type.product
         res.get
 

--- a/2023/04/part1.fz
+++ b/2023/04/part1.fz
@@ -6,7 +6,7 @@ dec4_part1 is
   lines := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines .filter !=""
 
   card(s String) is
-    wy(i) => ((s.split ":")[1].split "|")[i].split.map (.parse_i32.val)
+    wy(i) => ((s.split ":")[1].split "|")[i].split.map (.parse_i32.or_panic)
     win => wy 0
     you => wy 1
     matches => ((win.combine you (=)).filter x->x).count

--- a/2023/04/part2.fz
+++ b/2023/04/part2.fz
@@ -11,7 +11,7 @@ dec4_part2 is
     o.as_array
 
   card(s String) is
-    wy(i) => ((s.split ":")[1].split "|")[i].split.map (.parse_i32.val)
+    wy(i) => ((s.split ":")[1].split "|")[i].split.map (.parse_i32.or_panic)
     win => wy 0
     you => wy 1
     matches => ((win.combine you (=)).filter x->x).count

--- a/2023/05/part1.fz
+++ b/2023/05/part1.fz
@@ -10,7 +10,7 @@ dec5_part1 is
   ls := lines.as_array
 
   seeds := ls[0].split.drop 1
-                .map (.parse_i64.val)
+                .map (.parse_i64.or_panic)
                 .as_array
   range(start, len i64) is
     r => start + len
@@ -34,9 +34,9 @@ dec5_part1 is
       n.get
 
   conv(li Sequence String) is
-    to   := li[0].parse_i64.val
-    from := li[1].parse_i64.val
-    len  := li[2].parse_i64.val
+    to   := li[0].parse_i64.or_panic
+    from := li[1].parse_i64.or_panic
+    len  := li[2].parse_i64.or_panic
     l => from
     r => from+len
     convert(i i64) =>

--- a/2023/05/part2.fz
+++ b/2023/05/part2.fz
@@ -12,9 +12,9 @@ dec5_part2 is
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r Sequence u8 := [], r++n.val
+        r Sequence u8 := [], r++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0 else
+      while n.ok && n.or_panic.count > 0 else
         r
     _ : String is
       public redef utf8 Sequence u8 => o
@@ -23,7 +23,7 @@ dec5_part2 is
   ls := lines.as_array
 
   seeds := ls[0].split.drop 1
-                .map (.parse_i64.val)
+                .map (.parse_i64.or_panic)
                 .as_array
   seeds2 := array seeds.length/2 i->(range seeds[2*i] seeds[2*i+1])
   range(start, len i64) is
@@ -31,7 +31,7 @@ dec5_part2 is
     l => start
 
   maps => maps (ls.drop 2)
-  maps(ml) list map => if ml.is_empty || ml.first.val = "" then nil
+  maps(ml) list map => if ml.is_empty || ml.first.or_panic = "" then nil
                        else
                          h := (ml.drop 1).take_while !=""
                          r := ml.drop h.count+2
@@ -61,9 +61,9 @@ dec5_part2 is
       rs.flat_map range convert2
 
   conv(li Sequence String) is
-    to   := li[0].parse_i64.val
-    from := li[1].parse_i64.val
-    len  := li[2].parse_i64.val
+    to   := li[0].parse_i64.or_panic
+    from := li[1].parse_i64.or_panic
+    len  := li[2].parse_i64.or_panic
     l => from
     r => from+len
     convert(i i64) =>

--- a/2023/06/part1.fz
+++ b/2023/06/part1.fz
@@ -4,9 +4,9 @@ dec6_part1 is
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r Sequence u8 := [], r++n.val
+        r Sequence u8 := [], r++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0 else
+      while n.ok && n.or_panic.count > 0 else
         r
     _ : String is
       public redef utf8 Sequence u8 => o
@@ -15,7 +15,7 @@ dec6_part1 is
 
   l1 := lines[0].split.drop 1
   l2 := lines[1].split.drop 1
-  races := l1.zip l2 t,d->(race t.parse_i64.val d.parse_i64.val)
+  races := l1.zip l2 t,d->(race t.parse_i64.or_panic d.parse_i64.or_panic)
   race(t, d) is
     public redef as_string String => "Race {t}ms {d}mm"
     wins =>

--- a/2023/06/part2.fz
+++ b/2023/06/part2.fz
@@ -4,9 +4,9 @@ dec6_part1 is
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r Sequence u8 := [], r++n.val
+        r Sequence u8 := [], r++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0 else
+      while n.ok && n.or_panic.count > 0 else
         r
     _ : String is
       public redef utf8 Sequence u8 => o
@@ -15,9 +15,9 @@ dec6_part1 is
 
   l1 := lines[0].split.drop 1
   l2 := lines[1].split.drop 1
-  races := l1.zip l2 t,d->(race t.parse_i64.val d.parse_i64.val)
-  race2 := (race ((lines[0].split ":")[1].replace " " "").parse_i64.val
-                 ((lines[1].split ":")[1].replace " " "").parse_i64.val)
+  races := l1.zip l2 t,d->(race t.parse_i64.or_panic d.parse_i64.or_panic)
+  race2 := (race ((lines[0].split ":")[1].replace " " "").parse_i64.or_panic
+                 ((lines[1].split ":")[1].replace " " "").parse_i64.or_panic)
   race(t, d) is
     public redef as_string String => "Race {t}ms {d}mm"
     wins =>

--- a/2023/07/part1.fz
+++ b/2023/07/part1.fz
@@ -5,9 +5,9 @@
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r1 Sequence u8 := [], r1++n.val
+        r1 Sequence u8 := [], r1++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0
+      while n.ok && n.or_panic.count > 0
       else r1
     o
   bytes := bytes0
@@ -27,7 +27,7 @@
   handbid(str) =>
     s := str.split
     say s
-    handbid (hand s[0]) s[1].parse_i32.val
+    handbid (hand s[0]) s[1].parse_i32.or_panic
 
   handbid(h hand, bid i32) : property.orderable is
     public redef as_string String => "{h.s} $bid"
@@ -69,7 +69,7 @@
   r     := "omlkj987654321".codepoints
 
   hand(s String) : property.orderable is
-    rankedl := s.codepoints.map String x->{r[(ranks.find x).get] /* (codepoint (65+(ranks.find x).get).as_u32)*/}
+    rankedl := s.codepoints.map String x->{r[(ranks.find x).or_panic] /* (codepoint (65+(ranks.find x).or_panic).as_u32)*/}
     ranked := rankedl.fold String.type.concat
     sorted2 := container.sorted_array String rankedl (<=)
     sorted := sorted2.fold String.type.concat

--- a/2023/07/part2.fz
+++ b/2023/07/part2.fz
@@ -5,9 +5,9 @@
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r0 Sequence u8 := [], r0++n.val
+        r0 Sequence u8 := [], r0++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0 else
+      while n.ok && n.or_panic.count > 0 else
         r0
     o
   bytes := bytes0
@@ -27,11 +27,11 @@
   handbid(s) =>
     s2 := s.split
     say s2
-    handbid (hand s2[0]) s2[1].parse_i32.val
+    handbid (hand s2[0]) s2[1].parse_i32.or_panic
   handbid2(s) =>
     s2 := s.split
     say s2
-    handbid2 (hand s.codepoints[0]) s2[1].parse_i32.val
+    handbid2 (hand s.codepoints[0]) s2[1].parse_i32.or_panic
 
   handbid(h hand, bid i32) : property.orderable is
     public redef as_string String => "{h.s} $bid"
@@ -80,14 +80,14 @@
   r     := "omlkj98765432".codepoints
 
   hand(s String) : property.orderable is
-    rankedl := s.codepoints.map String x->{r[(ranks.find x).get] /* (codepoint (65+(ranks.find x).get).as_u32)*/}
+    rankedl := s.codepoints.map String x->{r[(ranks.find x).or_panic] /* (codepoint (65+(ranks.find x).or_panic).as_u32)*/}
     ranked := rankedl.fold String.type.concat
     sortedr := container.sorted_array String rankedl String.lteq
     sorted := sortedr.fold String.type.concat
     sa := sorted.codepoints.as_array
 
-    j2 String := r[(ranks2.find "J").get]
-    rankedl2 := s.codepoints.map String x->r[(ranks2.find x).get]
+    j2 String := r[(ranks2.find "J").or_panic]
+    rankedl2 := s.codepoints.map String x->r[(ranks2.find x).or_panic]
     ranked2 := rankedl2.fold String.type.concat
     sortedr2 := container.sorted_array String rankedl2 String.lteq
     sorted2 := sortedr2.fold String.type.concat

--- a/2023/08/part1.fz
+++ b/2023/08/part1.fz
@@ -4,9 +4,9 @@ dec8_part1 is
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r1 Sequence u8 := [], r1++n.val
+        r1 Sequence u8 := [], r1++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0
+      while n.ok && n.or_panic.count > 0
       else r1
     o
   bytes := bytes0
@@ -45,12 +45,12 @@ dec8_part1 is
                    _,l,r := t
                    fork name_to_num[l] name_to_num[r]
                  .as_array
-  start := name_to_num["AAA"].get
-  end   := name_to_num["ZZZ"].get
+  start := name_to_num["AAA"].or_panic
+  end   := name_to_num["ZZZ"].or_panic
   count := for i := start, next
                lr in lrs.cycle
                n in 1..
-               next := (forks[i].get lr).get
+               next := (forks[i].get lr).or_panic
            until next = end
              n
            else

--- a/2023/08/part2.fz
+++ b/2023/08/part2.fz
@@ -4,9 +4,9 @@ dec8_part2 is
     LM : mutate is
     o := LM ! ()->io.stdin.reader LM ! ()->
       for
-        r Sequence u8 := [], r++n.val
+        r Sequence u8 := [], r++n.or_panic
         n := (io.buffered LM .read_bytes 10000)
-      while n.ok && n.val.count > 0 else
+      while n.ok && n.or_panic.count > 0 else
         r
     o
   bytes := bytes0
@@ -42,11 +42,11 @@ dec8_part2 is
       if s  then l else r
   forks := tuples.map t->
                    _,l,r := t
-                   fork name_to_num[l].get name_to_num[r].get
+                   fork name_to_num[l].or_panic name_to_num[r].or_panic
                  .as_array
   part1 =>
-    start := name_to_num["AAA"].get
-    end   := name_to_num["ZZZ"].get
+    start := name_to_num["AAA"].or_panic
+    end   := name_to_num["ZZZ"].or_panic
     count := for i := start, next
                  lr in lrs.cycle
                  n in 1..
@@ -58,7 +58,7 @@ dec8_part2 is
     count
 
   part2 =>
-    start := (names.filter s->(s.ends_with "A")).map s->name_to_num[s].get
+    start := (names.filter s->(s.ends_with "A")).map s->name_to_num[s].or_panic
     end   := (names.map s->(s.ends_with "Z")).as_array
 
     lm : mutate is
@@ -90,7 +90,7 @@ dec8_part2 is
   # this crashed my whole Linux system while running in a JVM due to memory exhaustion...
   #
   part2_retired =>
-    start := (names.filter s->(s.ends_with "A")).map s->name_to_num[s].get
+    start := (names.filter s->(s.ends_with "A")).map s->name_to_num[s].or_panic
     say start.count
     end   := (names.map s->(s.ends_with "Z")).as_array
     #    say "$start -> $end"

--- a/2023/09/part1.fz
+++ b/2023/09/part1.fz
@@ -4,7 +4,7 @@ dec9_part1 is
   ls := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines
 
   # parse input into sequence of sequence of i32
-  seqs := ls.map s->(s.split.map (.parse_i32.val)).as_array
+  seqs := ls.map s->(s.split.map (.parse_i32.or_panic)).as_array
 
   # extend given sequence by one element
   #
@@ -13,7 +13,7 @@ dec9_part1 is
       0
     else
       di := extend (sq.map_pairs a,b->b-a).as_array       # extend diffs
-      sq.last.val + di                                        # use diffs to add  last
+      sq.last.or_panic + di                                        # use diffs to add  last
 
   ex := seqs.map (s -> extend s)
   part1 => ex.fold i32.type.sum

--- a/2023/09/part2.fz
+++ b/2023/09/part2.fz
@@ -4,7 +4,7 @@ dec9_part2 is
   ls := LM ! ()->(io.stdin.reader LM ! ()->io.buffered LM .read_lines)
 
   # parse input into sequence of sequence of i32
-  seqs := ls.map s->(s.split.map (.parse_i32.val)).as_array
+  seqs := ls.map s->(s.split.map (.parse_i32.or_panic)).as_array
 
   # find new first and last elements to extend given sequence at both ends
   #
@@ -13,7 +13,7 @@ dec9_part2 is
       (0,0)                                               # 0..0 is easy, just add 0 on both ends
     else
       di := extend (sq.map_pairs a,b->b-a).as_array       # extend diffs
-      (sq.first.val - di.0, sq.last.val + di.1)     # use diffs to determine first + last
+      (sq.first.or_panic - di.0, sq.last.or_panic + di.1)     # use diffs to determine first + last
 
   ex := (seqs.map (s -> extend s)).as_array
   part1 => (ex.map (.values.1)).fold i32.type.sum

--- a/2023/11/part1.fz
+++ b/2023/11/part1.fz
@@ -4,7 +4,7 @@ dec11_part1 is
   input := LM ! ()->
     io.stdin.reader LM ! ()->io.buffered LM .read_lines .filter !=""
      .map s->(s.codepoints.map (="#"))
-  image := array2 input.count input.first.val.count i,j->input[i][j]
+  image := array2 input.count input.first.or_panic.count i,j->input[i][j]
   part1 =>
     xs := image.indices0
     ys := image.indices1

--- a/2023/11/part2.fz
+++ b/2023/11/part2.fz
@@ -4,7 +4,7 @@ dec11_part2 is
   input := LM ! ()->
     io.stdin.reader LM ! ()->io.buffered LM .read_lines .filter !=""
      .map s->(s.codepoints.map (="#"))
-  image := array2 input.count input.first.val.count i,j->input[i][j]
+  image := array2 input.count input.first.or_panic.count i,j->input[i][j]
 
   part12(f u64) =>
     xs := image.indices0

--- a/2023/12/part1.fz
+++ b/2023/12/part1.fz
@@ -14,7 +14,7 @@ dec12_part1 is
              .codepoints)
             (s.split[1]
               .split ","
-              .map (.parse_i32.val)))
+              .map (.parse_i32.or_panic)))
 
   record(springs Sequence codepoint, groups Sequence i32) is
 

--- a/2023/12/part2.fz
+++ b/2023/12/part2.fz
@@ -15,7 +15,7 @@ dec12_part2 is
              .codepoints)
             (s.split[1]
               .split ","
-              .map (.parse_i32.val)))
+              .map (.parse_i32.or_panic)))
 
   record(springs Sequence codepoint, groups Sequence i32) is
 

--- a/2023/15/part2.fz
+++ b/2023/15/part2.fz
@@ -1,7 +1,7 @@
 dec15_part2 is
 
   LM : mutate is
-  input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_line .val
+  input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_line .or_panic
 
   hash(s String) => s.utf8.reduce 0 (h,c -> (h + c.as_i32) * 17 % 256)
 
@@ -12,7 +12,7 @@ dec15_part2 is
     lm ! ()->
       entry(is_add bool, s Sequence String) is
         k => s[0]
-        val  => s[1].trim.parse_i32.val
+        val  => s[1].trim.parse_i32.or_panic
       hm := (lm.array (Sequence entry)).type.new 256 []
       for e in input.split ","
                     .map (e -> if e.contains "=" then e.split "=" |> entry true

--- a/2023/15/part2_mini.fz
+++ b/2023/15/part2_mini.fz
@@ -1,14 +1,14 @@
 LM : mutate is
 input := LM ! ()->
-  io.stdin.reader LM ! ()->io.buffered LM .read_line .val.split ","
+  io.stdin.reader LM ! ()->io.buffered LM .read_line .or_panic.split ","
 hash(s String) => s.utf8.reduce 0 (h,c -> (h + c.as_i32) * 17 % 256)
 say "part1 {(input.map hash) .sum}"
 lm : mutate is
 lm ! ()->
   hm := (lm.array (Sequence (tuple String i32))).type.new 256 []
   input.for_each e->
-    k := e.substring 0 ((e.find "=").get) # (e.find "-").get)
-    p := (k, (e.split "=").last.get.parse_i32.val -1)
+    k := e.substring 0 ((e.find "=").or_panic) # (e.find "-").or_panic)
+    p := (k, (e.split "=").last.or_panic.parse_i32.or_panic-1)
     b := hm[hash k .as_i64]
     hm[hash k .as_i64] :=
        if      e.contains "-"        then b.filter (x -> x.values.0 != k)

--- a/2023/16/part2.fz
+++ b/2023/16/part2.fz
@@ -27,8 +27,8 @@ dec16_part2 is
 
   part1 => start 0 0 r
   part2 => (xs.map (x -> start x        0        d) ++
-            xs.map (x -> start x        ys.max.val u) ++
+            xs.map (x -> start x        ys.max.or_panic u) ++
             ys.map (y -> start 0        y        r) ++
-            ys.map (y -> start xs.max.val y        l)    ).reduce 0 max
+            ys.map (y -> start xs.max.or_panic y        l)    ).reduce 0 max
 
   say "part1 $part1 part2 $part2"

--- a/2023/17/part1.fz
+++ b/2023/17/part1.fz
@@ -5,7 +5,7 @@ dec17_part1 is
     .read_lines
     .filter !=""
     .map (.codepoints)
-  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.val
+  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.or_panic
   xs => area.indices1
   ys => area.indices0
 
@@ -26,7 +26,7 @@ dec17_part1 is
           if ol < 0 || ol > loss then
             la[ix y x dir str8 .as_i64] := loss
             modified <- true
-          if x = xs.max.val && y = ys.max.val && loss < res.get then
+          if x = xs.max.or_panic && y = ys.max.or_panic && loss < res.get then
             res <- loss
 
       update =>

--- a/2023/17/part2.fz
+++ b/2023/17/part2.fz
@@ -5,7 +5,7 @@ dec17_part2 is
     .read_lines
     .filter !=""
     .map (.codepoints)
-  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.val
+  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.or_panic
   xs => area.indices1
   ys => area.indices0
 
@@ -26,7 +26,7 @@ dec17_part2 is
           if ol < 0 || ol > loss then
             la[ix y x dir str8 .as_i64] := loss
             modified <- true
-          if x = xs.max.val && y = ys.max.val && str8 >= min_str8 && loss < res.get then
+          if x = xs.max.or_panic && y = ys.max.or_panic && str8 >= min_str8 && loss < res.get then
             res <- loss
 
       update =>

--- a/2023/18/part1.fz
+++ b/2023/18/part1.fz
@@ -6,7 +6,7 @@ dec18_part1 is
   data := input.map action
   action(s String) =>
     s3 := s.split " "
-    action s3[0] s3[1].parse_i32.val (s3[2].substring 2 8).parse_i32_hex.val
+    action s3[0] s3[1].parse_i32.or_panic (s3[2].substring 2 8).parse_i32_hex.or_panic
   action(dir String, len i32, col i32) is
 
   dirs := "UDLR"
@@ -26,7 +26,7 @@ dec18_part1 is
           max_x := px+1, max max_x px+1
           max_y := py+1, max max_y py+1
           a in data
-          d := (dirs.find a.dir).get
+          d := (dirs.find a.dir).or_panic
       do
         for i in 0..(a.len-1) do
           area[_,px+i*dx[d],py+i*dy[d]].n <- "#"

--- a/2023/18/part2.fz
+++ b/2023/18/part2.fz
@@ -6,10 +6,10 @@ dec18_part2 is
   data := input.map action
   action(s String) =>
     s3 := s.split " "
-    h := (s3[2].substring 2 8).parse_i32_hex.val
+    h := (s3[2].substring 2 8).parse_i32_hex.or_panic
     d2 := "RDLU".substring (h % 16) (h % 16)+1
     l2 := h / 16
-    action s3[0] s3[1].parse_i32.val d2 l2
+    action s3[0] s3[1].parse_i32.or_panic d2 l2
   action(dir String, len i32, dir2 String, len2 i32) is
 
   dirs := "UDLR"
@@ -28,7 +28,7 @@ dec18_part2 is
           max_x := px+1, max max_x px+1
           max_y := py+1, max max_y py+1
           a in data
-          d := (dirs.find a.dir).get
+          d := (dirs.find a.dir).or_panic
       do
         for i in 0..(a.len-1) do
           area[_,px+i*dx[d],py+i*dy[d]].n <- "#"

--- a/2024/01/part1.fz
+++ b/2024/01/part1.fz
@@ -6,7 +6,7 @@ dec1_part1 is
 
   data := input.map s->
     n := s.split "   "
-    (n[0].parse_i32.val, n[1].parse_i32.val)
+    (n[0].parse_i32.or_panic, n[1].parse_i32.or_panic)
 
   l := data.map x->x.0
   r := data.map x->x.1

--- a/2024/01/part2.fz
+++ b/2024/01/part2.fz
@@ -6,7 +6,7 @@ dec1_part2 is
 
   data := input.map s->
     n := s.split "   "
-    (n[0].parse_i32.val, n[1].parse_i32.val)
+    (n[0].parse_i32.or_panic, n[1].parse_i32.or_panic)
 
   l := data.map x->x.0
   r := data.map x->x.1

--- a/2024/02/part1.fz
+++ b/2024/02/part1.fz
@@ -3,7 +3,7 @@ dec2_part1 is
   LM : mutate is
   input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines.filter !=""
 
-  data := input.map (s -> (s.split " ").map (.parse_i32.val))
+  data := input.map (s -> (s.split " ").map (.parse_i32.or_panic))
 
   mono(s)  => s.map_pairs (<=)
                .map_pairs (=) ∀ id

--- a/2024/02/part2.fz
+++ b/2024/02/part2.fz
@@ -4,7 +4,7 @@ dec2_part2 is
   input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines.filter !=""
 
   data := input.map (.split " "
-                     .map (.parse_i32.val))
+                     .map (.parse_i32.or_panic))
 
   mono(s)  => s.map_pairs (<=)
                .map_pairs (=) ∀ id

--- a/2024/05/part1.fz
+++ b/2024/05/part1.fz
@@ -15,17 +15,17 @@ dec5_part1 =>
 
   is_less_than(a,b) =>
     input1.map (e -> e.split "|"
-                      .map (.parse_i32.val)
+                      .map (.parse_i32.or_panic)
                       .as_array)
           .filter (e -> e[0] = b && e[1] = a)
           .is_empty
 
-  mid(s) => s.drop s.count/2 .first.val
+  mid(s) => s.drop s.count/2 .first.or_panic
 
   part1 =>
     (input2.map s->
       n := s.split ","
-            .map (.parse_i32.val)
+            .map (.parse_i32.or_panic)
 #      say "$s {is_ordered n}"
 #      m := is_ordered n ? mid n : 0
 #      say m

--- a/2024/05/part2.fz
+++ b/2024/05/part2.fz
@@ -6,13 +6,13 @@ dec5_part2 =>
   # the relation defined by input as an array
   rel := input.filter (.contains "|")
               .map (.split "|"
-                    .map (.parse_i32.val)
+                    .map (.parse_i32.or_panic)
                     .as_array)
               .as_array
 
   # the page number sequences defined by input
   nums := input.filter (.contains ",")
-               .map (.split "," .map (.parse_i32.val))
+               .map (.split "," .map (.parse_i32.or_panic))
 
   # infix operator for rel
   infix <? (a,b) => rel ∀ (e -> e[0] != b || e[1] != a)
@@ -21,7 +21,7 @@ dec5_part2 =>
   is_ordered(s) => s.first ∀ (v -> t := s.drop 1; (t ∀ v<?) && is_ordered t)
 
   # middle element
-  mid(s) => s.drop s.count/2 .first.val
+  mid(s) => s.drop s.count/2 .first.or_panic
 
   part1 => nums.map (n -> is_ordered n ? mid n : 0)
                .sum

--- a/2024/06/part1.fz
+++ b/2024/06/part1.fz
@@ -14,7 +14,7 @@ dec6_part1 =>
   starty, startx := arr.indices.reduce (option (i32,i32) nil) a1,y->
      row := arr[y]
      row.indices.reduce a1 (a2,x -> row[x] = "^" ? (y,x) : a2)
-   .val
+   .or_panic
 
   part1 =>
     LM ! ()->

--- a/2024/06/part2.fz
+++ b/2024/06/part2.fz
@@ -19,7 +19,7 @@ dec6_part2 =>
           area[y,x] := data[_,y.as_i32, x.as_i32]
 
     start := data.index_pairs.filter (yx -> data[_,yx.0,yx.1] = "^")
-                             .first.val ||> y,x -> pos y.as_i64 x.as_i64
+                             .first.or_panic ||> y,x -> pos y.as_i64 x.as_i64
 
     # direction, bit gives a unique bit 1, 2, 4, 8
     dir(dy, dx i64) is

--- a/2024/07/part1.fz
+++ b/2024/07/part1.fz
@@ -3,15 +3,15 @@ dec7_part1 =>
   LM : mutate is
   input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines.filter !=""
 
-  total(s) => s.split ":" .first.val.parse_i64.val
-  nums(s) => s.split " " .drop 1 .map (.parse_i64.val) .as_array
+  total(s) => s.split ":" .first.or_panic .parse_i64.or_panic
+  nums(s) => s.split " " .drop 1 .map (.parse_i64.or_panic) .as_array
 
   test2(t, v, r) =>
     match r.as_list
       nil => t = v
       c Cons => (test2 t v*c.head c.tail ||
                  test2 t v+c.head c.tail    )
-  test(t, r) => test2 t r.first.val (r.drop 1)
+  test(t, r) => test2 t r.first.or_panic (r.drop 1)
 
   part1 =>
     input.filter (s -> test (total s) (nums s))

--- a/2024/07/part2.fz
+++ b/2024/07/part2.fz
@@ -3,9 +3,9 @@ dec7_part2 =>
   LM : mutate is
   input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines.filter !=""
 
-  total(s) => s.split ":" .first.val.parse_i64.val
-  nums(s) => s.split " " .drop 1 .map (.parse_i64.val)
-  num0(s) => nums s .first.val
+  total(s) => s.split ":" .first.or_panic.parse_i64.or_panic
+  nums(s) => s.split " " .drop 1 .map (.parse_i64.or_panic)
+  num0(s) => nums s .first.or_panic
   numr(s) => nums s .drop 1
 
   test1(t, v, n) =>
@@ -23,7 +23,7 @@ dec7_part2 =>
 
   integer.infix || (o integer.this) =>
     "{integer.this}$o".parse_integer (integer.this.from_u32 10)
-                      .val
+                      .or_panic
 
   part1 => input.filter (s -> test1 (total s) (num0 s) (numr s))
                 .map total

--- a/2024/07/part2b.fz
+++ b/2024/07/part2b.fz
@@ -1,8 +1,8 @@
 LM : mutate is
 input := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM .read_lines.filter !=""
 
-total(s) => s.split ":" .first.val.parse_i64.val
-nums(s) => s.split " " .drop 1 .map (.parse_i64.val)
+total(s) => s.split ":" .first.or_panic.parse_i64.or_panic
+nums(s) => s.split " " .drop 1 .map (.parse_i64.or_panic)
 
 test(ops, t, v, n) =>
   t >= v && match n.as_list
@@ -15,4 +15,4 @@ partn(ops Sequence (i64,i64)->i64) =>
        .sum
 
 say (partn [*, +])
-say (partn [*, +, (a,b)->"$a$b".parse_i64.val])
+say (partn [*, +, (a,b)->"$a$b".parse_i64.or_panic])

--- a/2024/09/part1.fz
+++ b/2024/09/part1.fz
@@ -3,7 +3,7 @@ dec9_part2 =>
   LM : mutate is
   LM ! ()->
     data := io.stdin.reader LM ! ()->io.buffered LM .read_lines
-             .filter !="" .first.val.codepoints.map (.parse_i64.val) .as_array
+             .filter !="" .first.or_panic.codepoints.map (.parse_i64.or_panic) .as_array
 
     Sequence.infix +++(a Sequence T) => Sequence.this.as_list.concat_eagerly a.as_list
 

--- a/2024/09/part2.fz
+++ b/2024/09/part2.fz
@@ -3,7 +3,7 @@ dec9_part2 =>
   LM : mutate is
   LM ! ()->
     data := io.stdin.reader LM ! ()->io.buffered LM .read_lines
-             .filter !="" .first.val.codepoints.map (.parse_i64.val) .as_array
+             .filter !="" .first.or_panic.codepoints.map (.parse_i64.or_panic) .as_array
     disk := data.zip ((i64 0 ..).flat_map (n -> id (Sequence i64) [n,-1])) a,b->(a,b)
                 .flat_map (||> n,id_ -> id (Sequence i64) ([id_].cycle.take n.as_i32))
                 .as_array

--- a/2024/10/part1.fz
+++ b/2024/10/part1.fz
@@ -4,7 +4,7 @@ dec10_part1 =>
   arr := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM
     .read_lines
     .filter !=""
-    .map (.codepoints.map (.parse_i32.get) .as_array)
+    .map (.codepoints.map (.parse_i32.or_panic) .as_array)
     .as_array
 
   h := arr.length;   # hl := h.as_i64

--- a/2024/10/part2.fz
+++ b/2024/10/part2.fz
@@ -4,7 +4,7 @@ dec10_part2 =>
   arr := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM
     .read_lines
     .filter !=""
-    .map (.codepoints.map (.parse_i32.get) .as_array)
+    .map (.codepoints.map (.parse_i32.or_panic) .as_array)
     .as_array
 
 

--- a/2024/10/part2a.fz
+++ b/2024/10/part2a.fz
@@ -4,7 +4,7 @@ dec10_part2 =>
   arr := LM ! ()->io.stdin.reader LM ! ()->io.buffered LM
     .read_lines
     .filter !=""
-    .map (.codepoints.map (.parse_i32.get) .as_array)
+    .map (.codepoints.map (.parse_i32.or_panic) .as_array)
     .as_array
 
 

--- a/2024/11/part1.fz
+++ b/2024/11/part1.fz
@@ -1,7 +1,7 @@
 dec11 =>
 
   input := io.stdin.read_string
-  data := input.trim.split " " .map (.parse_i64.val)
+  data := input.trim.split " " .map (.parse_i64.or_panic)
 
   f(n) Sequence i64 =>
     l := ($n).byte_length.as_i64

--- a/2024/11/part2.fz
+++ b/2024/11/part2.fz
@@ -1,7 +1,7 @@
 dec11 =>
 
   input := io.stdin.read_string
-  data := input.trim.split " " .map (.parse_i64.val)
+  data := input.trim.split " " .map (.parse_i64.or_panic)
 
   blink(b i64) =>
     M : mutate is

--- a/2024/13/part1.fz
+++ b/2024/13/part1.fz
@@ -9,7 +9,7 @@ dec13 =>
              .replace ", Y=" " "
              .replace "\n" " "
 #             .split "  " .map (.split " " .map (x->">"+x+"<"))
-             .split "  " .map (.split " " .filter !="" .map (.parse_i32.val))
+             .split "  " .map (.split " " .filter !="" .map (.parse_i32.or_panic))
              .map (x -> claw x[0] x[1] x[2] x[3] x[4] x[5])
 
   claw(ax,ay,bx,by,px,py) is

--- a/2024/13/part2.fz
+++ b/2024/13/part2.fz
@@ -8,7 +8,7 @@ dec13 =>
              .replace "Prize: X=" ""
              .replace ", Y=" " "
              .replace "\n" " "
-             .split "  " .map (.split " " .map (.parse_i64.val))
+             .split "  " .map (.split " " .map (.parse_i64.or_panic))
              .map (x -> claw x[0] x[1] x[2] x[3] x[4] x[5])
 
   claw(ax,ay,bx,by,px,py) is

--- a/2024/14/part1.fz
+++ b/2024/14/part1.fz
@@ -15,14 +15,14 @@ dec14 =>
              .split " " .as_array
   say "4: "+input4.count
   input5  := input4
-             .map (.parse_i64.val)
+             .map (.parse_i64.or_panic)
   say "5: "+input5.count
   input  := input5
              .as_4tuples.map ||||>robot
   say "6: "+input.count
 
-  w := envir.args[1].parse_i64.val
-  h := envir.args[2].parse_i64.val
+  w := envir.args[1].parse_i64.or_panic
+  h := envir.args[2].parse_i64.or_panic
 
   product(T type : numeric, l Sequence T) => l.fold T.product
 

--- a/2024/14/part2.fz
+++ b/2024/14/part2.fz
@@ -5,11 +5,11 @@ dec14 =>
              .replace "\n" " "
              .codepoints .filter (c -> "0" <= c <= "9" || c = " " || c = "-") .as_string ""
              .split " " .as_array
-             .map (.parse_i32.val)
+             .map (.parse_i32.or_panic)
              .as_4tuples.map ||||>robot
 
-  w := envir.args[1].parse_i32.val
-  h := envir.args[2].parse_i32.val
+  w := envir.args[1].parse_i32.or_panic
+  h := envir.args[2].parse_i32.or_panic
 
   robot(x,y,vx,vy) is
     move(n) =>

--- a/2024/15/part2.fz
+++ b/2024/15/part2.fz
@@ -124,8 +124,8 @@ dec15 =>
       for yx in a.index_pairs until yx ||> y,x->a[y,x] = "@"
         ryx <- yx
         input2.codepoints.for_each s->
-          f => if      "^v".contains s then d := ("^-v".find s).val.as_i64-1; moveV d
-               else if "<>".contains s then d := ("<->".find s).val.as_i64-1; moveH ryx.get d
+          f => if      "^v".contains s then d := ("^-v".find s).or_panic.as_i64-1; moveV d
+               else if "<>".contains s then d := ("<->".find s).or_panic.as_i64-1; moveH ryx.get d
                else panic "dir unknown $s"
 
           match f

--- a/2024/16/part2.fz
+++ b/2024/16/part2.fz
@@ -11,8 +11,8 @@ dec16 =>
       else if d=1 then point y   x-1
       else if d=2 then point y+1 x
       else             point y   x+1
-  e := area.index_pairs.filter (||> y,x->area[_,y,x]="E") .first.val ||> point
-  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.val ||> point
+  e := area.index_pairs.filter (||> y,x->area[_,y,x]="E") .first.or_panic ||> point
+  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.or_panic ||> point
 
   cost_of_turns(d1,d2) =>
     if      (d1 = d2)       then 0

--- a/2024/17/part1.fz
+++ b/2024/17/part1.fz
@@ -1,11 +1,11 @@
 dec17 =>
 
   input := io.stdin.read_lines
-  get(prefx) => input.filter (.starts_with prefx) .first.val.replace prefx ""
-  initial_A := get "Register A: " .parse_i32.val
-  initial_B := get "Register B: " .parse_i32.val
-  initial_C := get "Register C: " .parse_i32.val
-  code := get "Program: " .split "," .map (.parse_i32.val) .as_array
+  get(prefx) => input.filter (.starts_with prefx) .first.or_panic.replace prefx ""
+  initial_A := get "Register A: " .parse_i32.or_panic
+  initial_B := get "Register B: " .parse_i32.or_panic
+  initial_C := get "Register C: " .parse_i32.or_panic
+  code := get "Program: " .split "," .map (.parse_i32.or_panic) .as_array
 
   regs(a,b,c,pc,out) is
     public redef as_string String => "A:$a B:$b C:$c pc:$pc out:{out.as_string ","}"

--- a/2024/17/part2.fz
+++ b/2024/17/part2.fz
@@ -1,11 +1,11 @@
 dec17 =>
 
   input := io.stdin.read_lines
-  get(prefx) => input.filter (.starts_with prefx) .first.val.replace prefx ""
-  initial_A := get "Register A: " .parse_i64.val
-  initial_B := get "Register B: " .parse_i64.val
-  initial_C := get "Register C: " .parse_i64.val
-  code := get "Program: " .split "," .map (.parse_i64.val) .as_array
+  get(prefx) => input.filter (.starts_with prefx) .first.or_panic.replace prefx ""
+  initial_A := get "Register A: " .parse_i64.or_panic
+  initial_B := get "Register B: " .parse_i64.or_panic
+  initial_C := get "Register C: " .parse_i64.or_panic
+  code := get "Program: " .split "," .map (.parse_i64.or_panic) .as_array
 
   regs(a,b,c,pc,out) is
     ins => code[pc].as_i32

--- a/2024/18/part1.fz
+++ b/2024/18/part1.fz
@@ -1,9 +1,9 @@
 dec18 =>
 
-  w := envir.args[1].parse_i32.val
+  w := envir.args[1].parse_i32.or_panic
   wl := w.as_i64
-  l := envir.args[2].parse_i32.val
-  input := io.stdin.read_lines.filter !="" .map (.split "," .map s->s.parse_i32.val) .map s->(s[0],s[1])
+  l := envir.args[2].parse_i32.or_panic
+  input := io.stdin.read_lines.filter !="" .map (.split "," .map s->s.parse_i32.or_panic) .map s->(s[0],s[1])
                 .take l
 
   lm : mutate is

--- a/2024/18/part2.fz
+++ b/2024/18/part2.fz
@@ -1,10 +1,10 @@
 dec18 =>
 
-  wi := envir.args.count > 1 ? envir.args[1].parse_i32.val : 71
+  wi := envir.args.count > 1 ? envir.args[1].parse_i32.or_panic: 71
   w := wi.as_i64
   inside(x) => 0 <= x < w
-  l :=  envir.args.count > 2 ? envir.args[2].parse_i32.val : 1024
-  input2 := io.stdin.read_lines.filter !="" .map (.split "," .map s->s.parse_i64.val) .map s->(s[0],s[1])
+  l :=  envir.args.count > 2 ? envir.args[2].parse_i32.or_panic: 1024
+  input2 := io.stdin.read_lines.filter !="" .map (.split "," .map s->s.parse_i64.or_panic) .map s->(s[0],s[1])
   input1 := input2.map (||>x,y->(x.as_i32,y.as_i32)) .take l .as_array
   lm : mutate is
   lm ! ()->

--- a/2024/20/part1.fz
+++ b/2024/20/part1.fz
@@ -14,8 +14,8 @@ dec20 =>
     on_track => area[_,x,y] != "#"
     inner_wall => 1 <= x < w-1 && 1 <= y < h-1 && area[_,x,y] = "#"
 
-  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.val ||> point
-  e := area.index_pairs.filter (||> y,x->area[_,y,x]="E") .first.val ||> point
+  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.or_panic ||> point
+  e := area.index_pairs.filter (||> y,x->area[_,y,x]="E") .first.or_panic ||> point
 
   M : mutate is
   M ! ()->
@@ -23,7 +23,7 @@ dec20 =>
       picos := (M.array2 i32).type.new w.as_i64 h.as_i64 -1
       for p := s, p.neighbors.filter (.on_track)
                              .filter q->picos[q.xl,q.yl]<0
-                             .first.val
+                             .first.or_panic
           ps := 0, ps+1
       do
           picos[p.xl,p.yl] := ps

--- a/2024/20/part2.fz
+++ b/2024/20/part2.fz
@@ -1,6 +1,6 @@
 dec20 =>
 
-  min_saving := envir.args.count > 1 ? envir.args[1].parse_i32.val : 100
+  min_saving := envir.args.count > 1 ? envir.args[1].parse_i32.or_panic : 100
   input := io.stdin.read_lines.filter !="" .map (.codepoints)
   w := input[0].count
   h := input.count
@@ -18,7 +18,7 @@ dec20 =>
     infix + (o) => point x+o.x y+o.y
     infix - (o) => point x-o.x y-o.y
 
-  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.val ||> point
+  s := area.index_pairs.filter (||> y,x->area[_,y,x]="S") .first.or_panic ||> point
 
   M : mutate is
   M ! ()->
@@ -27,7 +27,7 @@ dec20 =>
     pico(p) => picos[p.xl,p.yl]
     for p := s, p.neighbors.filter (.on_track)
                            .filter (q -> pico q < 0)
-                           .first.val
+                           .first.or_panic
         ps := 0, ps+1
     do
       picos[p.xl,p.yl] := ps

--- a/2024/21/part1.fz
+++ b/2024/21/part1.fz
@@ -66,7 +66,7 @@ dec21 is
 
 
   fixed codepoint.as_key =>
-    if codepoint.ascii_digit.contains val then dec21.key parse_i32.val
+    if codepoint.ascii_digit.contains val then dec21.key parse_i32.or_panic
     else if "A" = codepoint.this then dec21.key dec21.a
     else panic "as_key for {codepoint.this}"
 
@@ -76,7 +76,7 @@ dec21 is
   fixed part1 =>
     lens := input.map (l -> shortest1 l (key a))
 
-    numparts := input.map (l->l.filter (c -> "0" <= c <= "9") .reduce "" (+) .parse_i32.val)
+    numparts := input.map (l->l.filter (c -> "0" <= c <= "9") .reduce "" (+) .parse_i32.or_panic)
     say "$lens \n $numparts"
     lens.zip numparts (*) .sum
 

--- a/2024/21/part2.fz
+++ b/2024/21/part2.fz
@@ -3,8 +3,8 @@ dec21 is
   input := io.stdin.read_lines.filter !=""
 
   # overlapping both layouts, put ` ` at (0,0)
-  codepoint.x => "741  <8520^v963AA>"  .find codepoint.this .val / 6
-  codepoint.y => "789#456#123# 0^A<v>#".find codepoint.this .val / 4 - 3
+  codepoint.x => "741  <8520^v963AA>"  .find codepoint.this .or_panic / 6
+  codepoint.y => "789#456#123# 0^A<v>#".find codepoint.this .or_panic / 4 - 3
 
   move(cur, next) =>
     dx := next.x - cur.x
@@ -32,7 +32,7 @@ dec21 is
 
   shortest(n) =>
     lengths := input.map (find_shortest n)
-    numeric_ := input.map (.codepoints.filter (c -> "0" <= c <= "9") .reduce "" (+) .parse_i64.val)
+    numeric_ := input.map (.codepoints.filter (c -> "0" <= c <= "9") .reduce "" (+) .parse_i64.or_panic)
     lengths.zip numeric_ (*)
            .sum
 

--- a/2024/22/part1.fz
+++ b/2024/22/part1.fz
@@ -1,6 +1,6 @@
 dec22 is
 
-  input := io.stdin.read_lines.filter !="" .map (.parse_i64.val)
+  input := io.stdin.read_lines.filter !="" .map (.parse_i64.or_panic)
 
   next(s0 i64) =>
     s1 := s0 * 64
@@ -18,7 +18,7 @@ dec22 is
   say (secrets (i64 123))
 
   part1 =>
-    input.map (seed -> secrets seed .drop 2000 .first.val) .sum
+    input.map (seed -> secrets seed .drop 2000 .first.or_panic) .sum
   part2 =>
 
   say "$part1:$part2"

--- a/2024/22/part2.fz
+++ b/2024/22/part2.fz
@@ -1,6 +1,6 @@
 dec22 is
 
-  input := io.stdin.read_lines.filter !="" .map (.parse_i64.val) .as_array
+  input := io.stdin.read_lines.filter !="" .map (.parse_i64.or_panic) .as_array
 
   i64.mixAndPrune(f i64->i64) => (val ^ f val) % 16777216
   next(s0 i64) =>
@@ -16,7 +16,7 @@ dec22 is
     prices seed .map (-) .map_pairs (-) .as_array
 
   part1 =>
-    input.map (seed -> secrets seed .drop 2000 .first.val) .sum
+    input.map (seed -> secrets seed .drop 2000 .first.or_panic) .sum
 
   part2 =>
     range => i64 -9 .. 9

--- a/2024/22/part2_group_map_reduce.fz
+++ b/2024/22/part2_group_map_reduce.fz
@@ -1,12 +1,12 @@
 dec22 is
 
-  input := io.stdin.read_lines.filter !="" .map (.parse_i64.val) .as_array
+  input := io.stdin.read_lines.filter !="" .map (.parse_i64.or_panic) .as_array
 
   i64.mixAndPrune(f i64->i64) => (val ^ f val) % 16777216
   i64.secrets => val :: .mixAndPrune *64 .mixAndPrune /32 .mixAndPrune *2048
 
   part1 =>
-    input.map (.secrets.drop 2000 .first.val)
+    input.map (.secrets.drop 2000 .first.or_panic)
          .sum
 
   # Part 2 is based on a solution in Scala by Karl Bielefeldt (@kbielefe)
@@ -17,7 +17,7 @@ dec22 is
                  .take 2001
                  .map %10
                  .sliding 5
-                 .group_map_reduce (.map_pairs (-) .as_array) (.last.val) x,_->x
+                 .group_map_reduce (.map_pairs (-) .as_array) (.last.or_panic) x,_->x
                  .items)
       .group_map_reduce x->x.0 x->x.1 (+)
       .values

--- a/2024/23/part2.fz
+++ b/2024/23/part2.fz
@@ -53,6 +53,6 @@ dec23 is
     part2 =>
       two_cliques := edges.map (e -> clique [e.v,e.w])
       largest two_cliques
-        .first.val.vs.map (.s) .sort.as_string ","
+        .first.or_panic.vs.map (.s) .sort.as_string ","
 
     say "$part1:$part2"

--- a/2024/24/part1.fz
+++ b/2024/24/part1.fz
@@ -25,14 +25,14 @@ dec24 is
     iws := in_wires.map (s -> s.split ": " |> (iw -> input_wire iw[0] iw[1]="1"))
     igs := in_gates.map (s -> s.split " "  |> (ig -> input_gate ig[0] ig[1] ig[2] ig[4]))
     ignore iws
-    bits := igs.map (.name) .filter (.starts_with "z") .map (.replace "z" "" .parse_i32.val) .fold1 max
+    bits := igs.map (.name) .filter (.starts_with "z") .map (.replace "z" "" .parse_i32.or_panic) .fold1 max
     ignore bits
     wires := iws.map (w -> id Wire w) ++ igs.map (w -> id Wire w)
     names := wires.map (.name)
     all_wires := (container.ps_map String Wire).new names wires
 
     get_state(name) =>
-      all_wires[name].val.state get_state
+      all_wires[name].or_panic.state get_state
     say bits
     for r := i64 0, r | ((get_state "z"+(i.as_string 2 10) ? i64 1 : i64 0) << i.as_i64) # NYI: CLEANUP: explicit type should not be necessary when type inference improves, see #5866
         i in 0..bits

--- a/2024/24/part2.fz
+++ b/2024/24/part2.fz
@@ -3,7 +3,7 @@ dec24 =>
   input := io.stdin.read_string.split "\n\n" .map (.split "\n" .filter !="")
   wires := (input[0].map (s -> s.split ": " |> (iw -> inpt iw[0] iw[1]="1"))         .map Wire id ++
             input[1].map (s -> s.split " "  |> (ig -> gate ig[0] ig[1] ig[2] ig[4])) .map Wire id   )
-  bits := wires.map (.name) .filter (.starts_with "z") .map (.replace "z" "" .parse_i64.val) .fold1 max
+  bits := wires.map (.name) .filter (.starts_with "z") .map (.replace "z" "" .parse_i64.or_panic) .fold1 max
   device := container.ps_map String Wire .new (wires.map (.name)) wires
 
   # any wire coming from input or gate
@@ -20,7 +20,7 @@ dec24 =>
       if x < 0 then
         state
       else
-        b := name.substring 1 .parse_i64.val
+        b := name.substring 1 .parse_i64.or_panic
         v := if      name.starts_with "x" then x
              else if name.starts_with "y" then y
              else panic "x y expected $name"
@@ -52,7 +52,7 @@ dec24 =>
          [gate.this])
 
   i64.z => "z"+(val.as_string 2 10)
-  wire(name) => device[name].val
+  wire(name) => device[name].or_panic
 
   # check if state of wire `name` is defined.
   # swap gives wires to swap,
@@ -95,14 +95,14 @@ dec24 =>
       until r0?? then r0 else nil
 
   part1 =>
-    for r := i64 0, r | (try_state [] 0 -1 -1 i.z .val ? (i64 1) : (i64 0)) << i # NYI: CLEANUP: explicit type should not be necessary when type inference improves, see #5866
+    for r := i64 0, r | (try_state [] 0 -1 -1 i.z .or_panic ? (i64 1) : (i64 0)) << i # NYI: CLEANUP: explicit type should not be necessary when type inference improves, see #5866
         i in (i64 0)..bits
     else
       $r
 
   part2 =>
     find_swap 0 []
-      .get
+      .or_panic
       .flat_map (t -> id (Sequence String) [t.0,t.1])
       .sort
       .as_string ","

--- a/2025/01/part1.fz
+++ b/2025/01/part1.fz
@@ -5,7 +5,7 @@ dec1 =>
              .replace "L" "-"
              .split "\n"
              .filter !=""
-             .map (.parse_i32.val)
+             .map (.parse_i32.or_panic)
 
   part1 =>
     input.foldf (50,0) e,x->

--- a/2025/01/part2.fz
+++ b/2025/01/part2.fz
@@ -5,7 +5,7 @@ dec1 =>
              .replace "L" "-"
              .split "\n"
              .filter !=""
-             .map (.parse_i32.val)
+             .map (.parse_i32.or_panic)
 
   part1 =>
     input.foldf (50,0) e,x->

--- a/2025/02/part1.fz
+++ b/2025/02/part1.fz
@@ -2,10 +2,10 @@ dec2 =>
 
   input := io.stdin.read_string
              .split "\n"
-             .first.val
+             .first.or_panic
              .split ","
              .flat_map (.split "-"
-                        .map (.parse_i64.val)
+                        .map (.parse_i64.or_panic)
                         .as_tuples)
 
   part1 =>

--- a/2025/02/part2.fz
+++ b/2025/02/part2.fz
@@ -2,10 +2,10 @@ dec2 =>
 
   input := io.stdin.read_string
              .split "\n"
-             .first.val
+             .first.or_panic
              .split ","
              .flat_map (.split "-"
-                        .map (.parse_i64.val)
+                        .map (.parse_i64.or_panic)
                         .as_tuples)
 
   ten := i64 10

--- a/2025/03/part1.fz
+++ b/2025/03/part1.fz
@@ -2,12 +2,12 @@ dec3 =>
 
   input := io.stdin.read_string.trim
              .split "\n"
-             .map (.codepoints.map (.parse_i32.val))
+             .map (.codepoints.map (.parse_i32.or_panic))
 
   part1 =>
     input.map l->
         d1 := l.take (l.count-1) .as_array.sort.reverse[0]
-        i := l.index_of d1 .val
+        i := l.index_of d1 .or_panic
         d2 := l.drop i+1 .sort.reverse[0]
         d1*10+d2
       .sum
@@ -17,7 +17,7 @@ dec3 =>
       v
     else
       d1 := l.take (l.count-n+1) .as_array.sort.reverse[0]
-      i := l.index_of d1 .val
+      i := l.index_of d1 .or_panic
       doit n+1 v*10+d1.as_i64 (l.drop i+1)
 
   part2 =>

--- a/2025/03/part2.fz
+++ b/2025/03/part2.fz
@@ -1,13 +1,13 @@
 dec3 =>
 
   input := io.stdin.read_string.trim.split "\n"
-             .map (.codepoints.map (.parse_i64.val))
+             .map (.codepoints.map (.parse_i64.or_panic))
 
   joltage(n,v,l) =>
     if n=0 then
       v
     else
-      d := l.take (l.count-n+1) .max.val
+      d := l.take (l.count-n+1) .max.or_panic
       joltage n-1 v*10+d (l.drop_while !=d .drop 1)
 
   part1 =>

--- a/2025/05/part1.fz
+++ b/2025/05/part1.fz
@@ -1,8 +1,8 @@
 dec5 =>
 
-  fr,id := io.stdin.read_string.trim.split "\n\n" .as_tuples.first.val
-  fresh := fr.split "\n" .map (.split "-" .map (.parse_i64.val) .as_tuple)
-  ids   := id.split "\n" .map (.parse_i64.val)
+  fr,id := io.stdin.read_string.trim.split "\n\n" .as_tuples.first.or_panic
+  fresh := fr.split "\n" .map (.split "-" .map (.parse_i64.or_panic) .as_tuple)
+  ids   := id.split "\n" .map (.parse_i64.or_panic)
 
   part1 =>
     ids.count (i -> fresh ∃ ||>a,b->a<=i<=b)

--- a/2025/05/part2.fz
+++ b/2025/05/part2.fz
@@ -1,8 +1,8 @@
 dec5 =>
 
-  fr,id := io.stdin.read_string.trim.split "\n\n" .as_tuples.first.val
-  fresh := fr.split "\n" .map (.split "-" .map (.parse_i64.val) .as_tuple)
-  ids   := id.split "\n" .map (.parse_i64.val)
+  fr,id := io.stdin.read_string.trim.split "\n\n" .as_tuples.first.or_panic
+  fresh := fr.split "\n" .map (.split "-" .map (.parse_i64.or_panic) .as_tuple)
+  ids   := id.split "\n" .map (.parse_i64.or_panic)
 
   none := fresh.take 0
 

--- a/2025/06/part1.fz
+++ b/2025/06/part1.fz
@@ -3,7 +3,7 @@ dec6 =>
   input := io.stdin.read_string.trim.split "\n" .map (.split " " .filter !="" .as_array) .as_array
   h := input.count
   w := input[0].count
-  tasks := (0..(w-1)).map x->(input[h-1][x], array h-1 y->input[y][x].parse_i64.val)
+  tasks := (0..(w-1)).map x->(input[h-1][x], array h-1 y->input[y][x].parse_i64.or_panic)
 
   part1 =>
     tasks.map t->

--- a/2025/06/part2.fz
+++ b/2025/06/part2.fz
@@ -7,12 +7,12 @@ dec6 =>
     a := input.map (.split.as_array) .as_array
     a[0].indices.map x->
                   op := a[h][x]
-                  (0..h-1).map y->a[y][x].parse_i64.val
+                  (0..h-1).map y->a[y][x].parse_i64.or_panic
                           .fold1 (if op="*" then * else +)
                 .sum
 
   part2 =>
-    w := input.map (.trim.byte_length) .max.val
+    w := input.map (.trim.byte_length) .max.or_panic
     i := input.map_to_array (.codepoints.as_array)
     next(c) =>
       if c<w && (0..h ∃ y->i[y][c]!=" ") then next c+1
@@ -22,7 +22,7 @@ dec6 =>
                  op := i[h][c]
                  (c..(next c)-2).map x->
                                   (0..h-1).foldf "" e,y->e+i[y][x]
-                                          .trim.parse_i64.val
+                                          .trim.parse_i64.or_panic
                                 .fold1 (op="*" ? * : +)
                .sum
 

--- a/2025/08/part1.fz
+++ b/2025/08/part1.fz
@@ -3,7 +3,7 @@ dec8 =>
   say "start"
   input0 := io.stdin.read_string.trim.split "\n" .flat_map (.split ",") .as_array
   say "start1"
-  input1 := input0.map (.parse_i64.val) .as_array
+  input1 := input0.map (.parse_i64.or_panic) .as_array
   say "start2"
   input2 := input1.as_3tuples .as_array
   say "start3"
@@ -62,7 +62,7 @@ dec8 =>
           .product
 
     classes := array input.length x->(1,x)
-    join 0 envir.args[1].parse_i32.val classes
+    join 0 envir.args[1].parse_i32.or_panic classes
 
 
 #    input

--- a/2025/08/part2.fz
+++ b/2025/08/part2.fz
@@ -1,9 +1,9 @@
 dec8 =>
 
   input := io.stdin.read_string.trim.split "\n"
-             .map (.split "," .map (.parse_i64.val) .as_array) .as_array
+             .map (.split "," .map (.parse_i64.or_panic) .as_array) .as_array
   n := input.length
-  m := envir.args.count < 2 ? 1000 : envir.args[1].parse_i32.val
+  m := envir.args.count < 2 ? 1000 : envir.args[1].parse_i32.or_panic
 
   pairs := (0..n-1).flat_map (i -> (i+1..n-1).map (pair i))
                    .sort

--- a/2025/09/part1.fz
+++ b/2025/09/part1.fz
@@ -1,7 +1,7 @@
 dec9 =>
 
   input := io.stdin.read_string.trim.split "\n"
-             .map (.split "," .map (.parse_i64.val) .as_tuple) .as_array
+             .map (.split "," .map (.parse_i64.or_panic) .as_tuple) .as_array
 
   part1 =>
     input.foldf (i64 0) e,a->

--- a/2025/09/part2.fz
+++ b/2025/09/part2.fz
@@ -1,7 +1,7 @@
 dec9 =>
 
   input := io.stdin.read_string.trim.split "\n"
-             .map (.split "," .map (.parse_i64.val) .as_tuple) .as_array
+             .map (.split "," .map (.parse_i64.or_panic) .as_tuple) .as_array
 
   # area or rectangle with corners a and b
   rect(a,b) => ((|a.0-b.0|)+1)*((|a.1-b.1|)+1)
@@ -13,8 +13,8 @@ dec9 =>
   part2 =>
     xs := input.map (.0) .unique .sort   # all used x coordinates
     ys := input.map (.1) .unique .sort   # all used y coordinates
-    x(v) => xs.find_key v .val.as_i64    # compress x to index in xs
-    y(v) => ys.find_key v .val.as_i64    # compress y to index in ys
+    x(v) => xs.find_key v .or_panic.as_i64    # compress x to index in xs
+    y(v) => ys.find_key v .or_panic.as_i64    # compress y to index in ys
 
     m : mutate is
     m ! ()->

--- a/2025/10/part1.fz
+++ b/2025/10/part1.fz
@@ -7,7 +7,7 @@ dec10 =>
     lights := s[0].substring 1 s[0].byte_length-1 .codepoints.foldf (i32,i32) (0,1) e,c->
                 (e.0|(c="#"?e.1:0),2*e.1)
                .0
-    buttons := (s.drop 1 .take s.count-2).map (b->b.substring 1 b.byte_length-1 .split "," .foldf 0 e,c->e|1<<c.parse_i32.val)
+    buttons := (s.drop 1 .take s.count-2).map (b->b.substring 1 b.byte_length-1 .split "," .foldf 0 e,c->e|1<<c.parse_i32.or_panic)
 #    say buttons
 #    say "{lights.bin} {buttons.map (.bin)}"
     try(l,n) =>

--- a/2025/10/part2.fz
+++ b/2025/10/part2.fz
@@ -11,13 +11,13 @@ dec10 =>
     buttons := (s.drop 1 .take s.count-2).map (.replace "(" ""
                                                .replace ")" ""
                                                .split ","
-                                               .map c->1<<c.parse_i32.val
+                                               .map c->1<<c.parse_i32.or_panic
                                                .fold1 (|))
                                          .as_array
-    joltage := s.last.val.replace "\{" ""
+    joltage := s.last.or_panic.replace "\{" ""
                          .replace "\}" ""
                          .split ","
-                         .map (.parse_i32.val)
+                         .map (.parse_i32.or_panic)
 
     try(l,n) =>
       l=lights || n!=0 && (buttons ∃ b->try l^b n-1)
@@ -35,7 +35,7 @@ dec10 =>
                 j2 := j.indexed.map ||>i,jo->(jo - (pr.map b->(b>>i)%2 .sum))/2
                 m.ones_count + 2 * solve j2                 # recurse with halved joltage
               else 1000000
-            .min.val
+            .min.or_panic
       solve joltage
 
   part1 =>

--- a/2025/11/part1.fz
+++ b/2025/11/part1.fz
@@ -6,7 +6,7 @@ dec11 =>
              .map (.split ": " .as_tuple)
   names := (input.map (.0) ++ ["out"]).as_array
   nums := container.hash_map names 0..names.count-1
-  nm(name String) => nums[name].val
+  nm(name String) => nums[name].or_panic
   say "A"
   nodes := input.map t->(node (nm t.0) (t.1.split " " .map nm))
              .as_array

--- a/2025/12/part1.fz
+++ b/2025/12/part1.fz
@@ -2,8 +2,8 @@ dec12 =>
 
   input := io.stdin.read_string.trim.split "\n\n" .as_array
   grids := input[6].split "\n" .map (.split ": ")
-  areas := grids.map (g->g[0].split "x" .map (.parse_i32.val))
-  pcnts := grids.map (g->g[1].split " " .map (.parse_i32.val))
+  areas := grids.map (g->g[0].split "x" .map (.parse_i32.or_panic))
+  pcnts := grids.map (g->g[1].split " " .map (.parse_i32.or_panic))
 
   part1 =>
     # just stupidly count if the number of #s would fit, ignoring the

--- a/2025/12/part2.fz
+++ b/2025/12/part2.fz
@@ -11,8 +11,8 @@ dec12 =>
 
     input.lines.filter (.contains "x")
          .map (.split ": " .as_tuple)
-         .count ||>a,p->(a.split "x" .map (.parse_i32.val) .product >=
-                         p.split " " .map (.parse_i32.val) .zip presents (*) .sum)
+         .count ||>a,p->(a.split "x" .map (.parse_i32.or_panic) .product >=
+                         p.split " " .map (.parse_i32.or_panic) .zip presents (*) .sum)
 
   part2 =>
     "Merry Christmas"


### PR DESCRIPTION
Update examples to use the new `switch.or_panic` and `switch.or_default` APIs instead of the `removed switch.val`.