### PR TITLE
fix skipped examples: `env` now necessary due to API changes

### DIFF
--- a/2024/14/part1.fz
+++ b/2024/14/part1.fz
@@ -21,8 +21,8 @@ dec14 =>
              .as_4tuples.map ||||>robot
   say "6: "+input.count
 
-  w := envir.args[1].parse_i64.or_panic
-  h := envir.args[2].parse_i64.or_panic
+  w := envir.args.env[1].parse_i64.or_panic
+  h := envir.args.env[2].parse_i64.or_panic
 
   product(T type : numeric, l Sequence T) => l.fold T.product
 

--- a/2024/14/part2.fz
+++ b/2024/14/part2.fz
@@ -8,8 +8,8 @@ dec14 =>
              .map (.parse_i32.or_panic)
              .as_4tuples.map ||||>robot
 
-  w := envir.args[1].parse_i32.or_panic
-  h := envir.args[2].parse_i32.or_panic
+  w := envir.args.env[1].parse_i32.or_panic
+  h := envir.args.env[2].parse_i32.or_panic
 
   robot(x,y,vx,vy) is
     move(n) =>

--- a/2025/02/part1.fz
+++ b/2025/02/part1.fz
@@ -12,7 +12,7 @@ dec2 =>
     say input.as_string_all
     input.map (||> a,b->
         a0 := if ($a).byte_count %% 2 then a
-                                       else (i64 10)**(($a).byte_count.as_i64)
+                                      else (i64 10)**(($a).byte_count.as_i64)
         say "$a-$b\t$a0"
         hl := ($a0).byte_count / 2
         f := (i64 10)**hl.as_i64


### PR DESCRIPTION
Also fix indentation in one example