### PR TITLE
fix performance problem in `2023/16/part2.fz` and `2023/17`

### DIFF
--- a/2023/16/part2.fz
+++ b/2023/16/part2.fz
@@ -4,8 +4,8 @@ dec16_part2 is
              .filter !=""
              .map (.codepoints)
   area := array2 String _ input.count input[0].count i,j->input[i][j]
-  xs => area.indices1.map (.as_i32)
-  ys => area.indices0.map (.as_i32)
+  xs => area.indices1
+  ys => area.indices0
 
   r => {0}; l => {1}; u => {2}; d => {3}
   start(x0,y0,w0 i32) =>
@@ -14,7 +14,7 @@ dec16_part2 is
       visited := (lm.array i32).type.new area.length.as_i64 0
       ix(x,y) => y+x*area.length1.as_i32
       trace(x,y,w i32) unit =>
-        if ((xs.contains x) && (ys.contains y) &&
+        if ((x.as_i64 ∈ xs) && (y.as_i64 ∈ ys) &&
             (visited[ix x y .as_i64] & (1 << w)) = 0) then
           visited[ix x y .as_i64] := visited[ix x y .as_i64] | (1 << w)
           c := area[_,y,x]
@@ -26,9 +26,9 @@ dec16_part2 is
       (visited.as_array.filter !=0).count
 
   part1 => start 0 0 r
-  part2 => (xs.map (x -> start x        0        d) ++
-            xs.map (x -> start x        ys.max.or_panic u) ++
-            ys.map (y -> start 0        y        r) ++
-            ys.map (y -> start xs.max.or_panic y        l)    ).reduce 0 max
+  part2 => (xs.map (x -> start x.as_i32               0                      d) ++
+            xs.map (x -> start x.as_i32               ys.max.or_panic.as_i32 u) ++
+            ys.map (y -> start 0                      y.as_i32               r) ++
+            ys.map (y -> start xs.max.or_panic.as_i32 y.as_i32               l)).reduce 0 max
 
   say "part1 $part1 part2 $part2"

--- a/2023/17/part1.fz
+++ b/2023/17/part1.fz
@@ -5,26 +5,26 @@ dec17_part1 is
     .read_lines
     .filter !=""
     .map (.codepoints)
-  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.or_panic
-  xs => area.indices1.map (.as_i32)
-  ys => area.indices0.map (.as_i32)
+  area := array2 input.count input[0].count i,j->input[i][j].parse_i64.or_panic
+  xs => area.indices1
+  ys => area.indices0
 
-  r => {0}; l => {1}; u => {2}; d => {3}
+  r => {(i64 0)}; l => {(i64 1)}; u => {(i64 2)}; d => {(i64 3)}
 
   part1 =>
     lm : mutate is
     lm ! ()->
-      ix(y, x, dir, str8) => ((y*area.length1.as_i32+x)*4+dir)*3+str8
-      la := (lm.array i32).type.new (area.length0*area.length1*4*3).as_i64 -1
+      ix(y, x, dir, str8 i64) => ((y*area.length1+x)*4+dir)*3+str8
+      la := (lm.array i64).type.new (area.length0*area.length1*4*3) -1
       modified := lm.env.new false
-      res := lm.env.new i32.type.max
+      res := lm.env.new i64.type.max
 
-      put(x, y, dir, str8, loss0 i32) =>
-        if  (xs.contains x) && (ys.contains y) then
+      put(x, y, dir, str8, loss0 i64) =>
+        if  (x ∈ xs) && (y ∈ ys) then
           loss := loss0 + area[_,y,x]
-          ol := la[ix y x dir str8 .as_i64];
+          ol := la[ix y x dir str8];
           if ol < 0 || ol > loss then
-            la[ix y x dir str8 .as_i64] := loss
+            la[ix y x dir str8] := loss
             modified <- true
           if x = xs.max.or_panic && y = ys.max.or_panic && loss < res.get then
             res <- loss
@@ -33,8 +33,8 @@ dec17_part1 is
         for y in ys do
           for x in xs do
             for dir in r..d do
-              for str8 in 0..2 do
-                loss := if y=0 && x=0 then 0 else la[ix y x dir str8 .as_i64]
+              for str8 in (i64 0)..2 do
+                loss := if y=0 && x=0 then 0 else la[ix y x dir str8]
                 if loss >= 0 then
                   if (dir = u || dir = d) || dir = r && str8+1 < 3 then put x+1 y r (dir = r ? str8+1 : 0) loss
                   if (dir = u || dir = d) || dir = l && str8+1 < 3 then put x-1 y l (dir = l ? str8+1 : 0) loss

--- a/2023/17/part2.fz
+++ b/2023/17/part2.fz
@@ -5,26 +5,26 @@ dec17_part2 is
     .read_lines
     .filter !=""
     .map (.codepoints)
-  area := array2 input.count input[0].count i,j->input[i][j].parse_i32.or_panic
-  xs => area.indices1.map (.as_i32)
-  ys => area.indices0.map (.as_i32)
+  area := array2 input.count input[0].count i,j->input[i][j].parse_i64.or_panic
+  xs => area.indices1
+  ys => area.indices0
 
-  r => {0}; l => {1}; u => {2}; d => {3}
+  r => {(i64 0)}; l => {(i64 1)}; u => {(i64 2)}; d => {(i64 3)}
 
-  part12(min_str8, max_str8) =>
+  part12(min_str8, max_str8 i64) =>
     lm : mutate is
     lm ! ()->
-      ix(y, x, dir, str8) => ((y*area.length1.as_i32+x)*4+dir)*max_str8+str8
-      la := (lm.array i32).type.new (area.length0*area.length1*4*max_str8.as_i64) -1
+      ix(y, x, dir, str8) => ((y*area.length1+x)*4+dir)*max_str8+str8
+      la := (lm.array i64).type.new (area.length0*area.length1*4*max_str8) -1
       modified := lm.env.new false
-      res := lm.env.new i32.type.max
+      res := lm.env.new i64.type.max
 
-      put(x, y, dir, str8, loss0 i32) =>
-        if  (xs.contains x) && (ys.contains y) then
+      put(x, y, dir, str8, loss0 i64) =>
+        if  (x ∈ xs) && (y ∈ ys) then
           loss := loss0 + area[_,y,x]
-          ol := la[ix y x dir str8 .as_i64];
+          ol := la[ix y x dir str8 ];
           if ol < 0 || ol > loss then
-            la[ix y x dir str8 .as_i64] := loss
+            la[ix y x dir str8 ] := loss
             modified <- true
           if x = xs.max.or_panic && y = ys.max.or_panic && str8 >= min_str8 && loss < res.get then
             res <- loss
@@ -33,8 +33,8 @@ dec17_part2 is
         for y in ys do
           for x in xs do
             for dir in r..d do
-              for str8 in 0..(max_str8-1) do
-                loss := if y=0 && x=0 then 0 else la[ix y x dir str8 .as_i64]
+              for str8 in (i64 0)..(max_str8-1) do
+                loss := if y=0 && x=0 then (i64 0) else la[ix y x dir str8]
                 if loss >= 0 then
                   if (dir = u || dir = d) && str8+1 >= min_str8 || dir = r && str8+1 < max_str8 then put x+1 y r (dir = r ? str8+1 : 0) loss
                   if (dir = u || dir = d) && str8+1 >= min_str8 || dir = l && str8+1 < max_str8 then put x-1 y l (dir = l ? str8+1 : 0) loss


### PR DESCRIPTION

`.contains`/`∈` is just a comparison for an `interval` while it does a search in `Sequence`/`array`.

It seems to me that that is the only thing that changed.